### PR TITLE
Added use for failing libraries

### DIFF
--- a/lib/Module/Build/XSUtil.pm
+++ b/lib/Module/Build/XSUtil.pm
@@ -4,6 +4,9 @@ use strict;
 use warnings;
 use Config;
 use Module::Build;
+use IO::File;
+use File::Path;
+use File::Basename;
 our @ISA = qw(Module::Build);
 
 our $VERSION = "0.06";


### PR DESCRIPTION
We had an issue with one of our build jobs with your module which was causing some failures.  It turned out that via some combination of other prerequisites IO::File hadn't been loaded by anything else.  The failures were caused because your module relies on them but does not use/require them and as such it was dying.

I've added the relevant uses, they could be turned into requires if you so desire.

I would have written a test for this but I'm not sure of an easy way to test compiling an XS module and there were no examples in the test directory I could compare with.  If you could give me some pointers on writing a test case for it I'm happy to write one.

When I examined the code more closely I found a couple of other modules which may not neccesarily be loaded before your module which I also added as uses.  The list is below.

I haven't included a version bump with this pull request so you may need to do that if you merge and push to cpan.

File::Path
File::Basename
IO::File
