### PR TITLE
Fix STATIC_INLINE for gcc -std=c89

### DIFF
--- a/lib/Module/Build/XSUtil.pm
+++ b/lib/Module/Build/XSUtil.pm
@@ -315,7 +315,7 @@ sub _xshelper_h {
 :/* portability stuff not supported by ppport.h yet */
 :
 :#ifndef STATIC_INLINE /* from 5.13.4 */
-:# if defined(__GNUC__) || defined(__cplusplus) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L))
+:# if defined(__cplusplus) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L))
 :#   define STATIC_INLINE static inline
 :# else
 :#   define STATIC_INLINE static


### PR DESCRIPTION
According to [1], the __GNUC__ macro is always defined for a gcc-compilant
compiler, whether it is in strict C standard mode or in GNU mode. This
causes the STATIC_INLINE macro to always expand to "static inline" on
gcc/clang, even in C89 mode where "inline" is not defined.

Unfortunately, there does not seem to be a gcc macro that checks for GNU
mode, so this is fixed by removing the check on __GNUC__.

[1]: https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html