### PR TITLE
Fix for gcc

### DIFF
--- a/lib/Module/Build/XSUtil.pm
+++ b/lib/Module/Build/XSUtil.pm
@@ -214,7 +214,7 @@ sub _llvm_version {
 
 sub _gcc_version {
     my $res = `$Config{cc} --version`;
-    my ($version) = $res =~ /\(GCC\) ([0-9.]+)/;
+    my ($version) = $res =~ /(?:\(GCC\)|g?cc \([^)]+\)) ([0-9.]+)/;
     no warnings 'numeric', 'uninitialized';
     return sprintf '%g', $version;
 }

--- a/lib/Module/Build/XSUtil.pm
+++ b/lib/Module/Build/XSUtil.pm
@@ -79,6 +79,13 @@ sub new {
     if ( $args{needs_compiler_c99} ) {
         require Devel::CheckCompiler;
         Devel::CheckCompiler::check_c99_or_exit();
+
+        if ( _is_gcc() ) {
+            my $gccversion = _gcc_version();
+            if ( $gccversion < 5 ) {
+                $self->_add_extra_compiler_flags('-std=c99');
+            }
+        }
     }
 
     if ( $args{cc_warnings} ) {


### PR DESCRIPTION
#### Fix regexp of `_gcc_version` for Ubuntu and Debian

`_gcc_version` returns 0 on Ubuntu/Debian system which uses `gcc` as default compiler. Because those `cc --version` are different from normal `gcc --version`.

#### Set `-std=c99` explicitly for older GCC

Older gcc uses `-std=gnu89` as default. `gnu89` supports only some C99 features. It does not support `for loop initial declaration` etc. So `-std=c99` should be set explicitly for older GCC. (GCC 5.0 or higher uses `-std=gnu11`, so it does not need `-std=c99` option).

Related topic
- https://github.com/tokuhirom/mRuby.pm/pull/3
- https://github.com/tokuhirom/Devel-CheckCompiler/pull/4
