### PR TITLE
Relax perl requirement 5.8.5 -> 5.8.1

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl' => '5.008005';
+requires 'perl' => '5.008001';
 requires 'parent' => '0',
 requires 'Exporter' => '0',
 requires 'XSLoader' => 0.02,

--- a/lib/Module/Build/XSUtil.pm
+++ b/lib/Module/Build/XSUtil.pm
@@ -1,5 +1,5 @@
 package Module::Build::XSUtil;
-use 5.008005;
+use 5.008001;
 use strict;
 use warnings;
 use Config;


### PR DESCRIPTION
[The Lancaster Consensus](https://github.com/Perl-Toolchain-Gang/toolchain-site/blob/master/lancaster-consensus.md) says that the Perl toolchain will target Perl 5.8.1.

Module-Build-XSUtil is a toolchain, so it is nice that it supports perl 5.8.1.

This PR changes the minimum-supported perl from 5.8.5 to 5.8.1.

I confirmed that the all tests of Module-Build-XSUtil passed with perl 5.8.1:
```
❯ perl -v

This is perl, v5.8.1 built for darwin-2level
(with 1 registered patch, see perl -V for more detail)

Copyright 1987-2003, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using `man perl' or `perldoc perl'.  If you have access to the
Internet, point your browser at http://www.perl.com/, the Perl Home Page.

❯ prove -l t
t/00_compile.t .. ok
t/01_build.t .... ok
All tests successful.
Files=2, Tests=3,  1 wallclock secs ( 0.02 usr  0.00 sys +  0.83 cusr  0.18 csys =  1.03 CPU)
Result: PASS
```
