### PR TITLE
set -Wdeclaration-after-statement only if $] < 5.036

### DIFF
--- a/lib/Module/Build/XSUtil.pm
+++ b/lib/Module/Build/XSUtil.pm
@@ -237,7 +237,7 @@ sub _cc_warnings {
         my $gccversion = $self->_gcc_version();
         if ( $gccversion >= 4.0 ) {
             push @flags, qw(-Wextra);
-            if ( !( $args->{needs_compiler_c99} or $args->{needs_compiler_cpp} ) ) {
+            if ( $] < 5.036 && !( $args->{needs_compiler_c99} or $args->{needs_compiler_cpp} ) ) {
 
                 # Note: MSVC++ doesn't support C99,
                 # so -Wdeclaration-after-statement helps


### PR DESCRIPTION
Currently if we build the Mouse module (that uses Module-Build-XSUtil) on perl 5.40, we get:
> warning: ISO C90 forbids mixed declarations and code`

```
❯ pwd
/home/skaji/src/github.com/xslate/p5-Mouse

❯ perl -v
This is perl 5, version 40, subversion 0 (v5.40.0) built for x86_64-linux

❯ perl Build.PL
Created MYMETA.yml and MYMETA.json
Creating new 'Build' script for 'Mouse' version 'v2.5.10'

❯ ./Build
Building Mouse
Generate Mouse::Tiny ...
done.
cc -Ixs-src -I/home/skaji/env/plenv/versions/relocatable-5.40.0.0/lib/5.40.0/x86_64-linux/CORE -fPIC -Wall -Wextra -Wdeclaration-after-statement -Wc++-compat -c '-std=gnu99' -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE '-D_FILE_OFFSET_BITS=64' '-D_FORTIFY_SOURCE=2' -O2 -g -o xs-src/MouseAttribute.o xs-src/MouseAttribute.c
In file included from /home/skaji/env/plenv/versions/relocatable-5.40.0.0/lib/5.40.0/x86_64-linux/CORE/perl.h:46,
                 from xs-src/xshelper.h:36,
                 from xs-src/mouse.h:17,
                 from xs-src/MouseAttribute.xs:1:
/home/skaji/env/plenv/versions/relocatable-5.40.0.0/lib/5.40.0/x86_64-linux/CORE/inline.h: In function ‘Perl_av_remove_offset’:
/home/skaji/env/plenv/versions/relocatable-5.40.0.0/lib/5.40.0/x86_64-linux/CORE/config.h:1211:17: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
 1211 | #define SSize_t ssize_t /* signed count of bytes */
      |                 ^~~~~~~
...
```

This is because perl 5.36+ may use C99 features.
See https://metacpan.org/release/HAARG/perl-5.40.0/view/pod/perl5360delta.pod#Configuration-and-Compilation

So I think we should set -Wdeclaration-after-statement only if $] < 5.036.